### PR TITLE
fix: Proper support for patternProperties used with unknownProperties

### DIFF
--- a/lib/revalidator.js
+++ b/lib/revalidator.js
@@ -354,11 +354,9 @@
 
         // deleteUnknownProperties
         if (options.deleteUnknownProperties) {
-            props = schema.properties ? Object.keys(schema.properties) : [];
-            props = props.concat(schema.patternProperties ? Object.keys(schema.patternProperties) : []);
             for (p in object) {
                 if (object.hasOwnProperty(p)) {
-                    if (props.indexOf(p) === -1) {
+                    if (visitedProps.indexOf(p) === -1) {
                         delete object[p];
                     }
                 }
@@ -367,11 +365,9 @@
 
         // unknownProperties
         if (options.unknownProperties) {
-            props = schema.properties ? Object.keys(schema.properties) : [];
-            props = props.concat(schema.patternProperties ? Object.keys(schema.patternProperties) : []);
             for (p in object) {
                 if (object.hasOwnProperty(p)) {
-                    if (props.indexOf(p) === -1) {
+                    if (visitedProps.indexOf(p) === -1) {
                         if (options.unknownProperties === 'delete') {
                             delete object[p];
                         } else if (options.unknownProperties === 'error') {


### PR DESCRIPTION
Hi there. We come to some situation when we define validation rules using patternProperties. Properties are gets validated but then they are still considered as unknown. Current code doesn't treat them properly. Here is the patch that fixes it.
